### PR TITLE
Add in-memory loading functionality for Cadova Viewer 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,0 @@
-.DS_Store
-/.build
-/Packages
-/*.xcodeproj
-*xcuserdata/
-/.swiftpm
-
-/.claude/settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+*xcuserdata/
+/.swiftpm
+
+/.claude/settings.local.json

--- a/Cadova Viewer/AppDelegate.swift
+++ b/Cadova Viewer/AppDelegate.swift
@@ -4,6 +4,13 @@ import SwiftUI
 @main
 class AppDelegate: NSObject, NSApplicationDelegate {
     var preferencesWindow: NSWindow?
+    private var previewListener: PreviewListener?
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        let listener = PreviewListener()
+        listener.start()
+        previewListener = listener
+    }
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows: Bool) -> Bool {
         if !hasVisibleWindows {

--- a/Cadova Viewer/CadovaViewer.entitlements
+++ b/Cadova Viewer/CadovaViewer.entitlements
@@ -7,5 +7,9 @@
 		<string>$(PRODUCT_BUNDLE_IDENTIFIER)-spks</string>
 		<string>$(PRODUCT_BUNDLE_IDENTIFIER)-spki</string>
 	</array>
+	<key>com.apple.security.temporary-exception.mach-register.global-name</key>
+	<array>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER).preview</string>
+	</array>
 </dict>
 </plist>

--- a/Cadova Viewer/Document/Document.swift
+++ b/Cadova Viewer/Document/Document.swift
@@ -116,4 +116,10 @@ class Document: NSDocument, NSWindowDelegate {
     func window(_ window: NSWindow, willUseFullScreenPresentationOptions proposedOptions: NSApplication.PresentationOptions = []) -> NSApplication.PresentationOptions {
         proposedOptions.union(.autoHideToolbar)
     }
+
+    func loadFrom(data: Data, name: String) async throws {
+        displayName = name
+        let model = try await ModelData(data: data)
+        modelSubject.send(model)
+    }
 }

--- a/Cadova Viewer/Document/DocumentHostingController.swift
+++ b/Cadova Viewer/Document/DocumentHostingController.swift
@@ -21,7 +21,7 @@ class DocumentHostingController: NSHostingController<DocumentView> {
         usedCategoryMasks |= (1 << viewportID)
         viewportControllers.append(viewportController)
 
-        super.init(rootView: DocumentView(url: document.fileURL!, errorHandler: { [weak document] error in
+        super.init(rootView: DocumentView(url: document.fileURL, errorHandler: { [weak document] error in
             document?.presentError(error)
         }, viewportController: viewportController))
     }

--- a/Cadova Viewer/Preview/CadovaPreviewService.swift
+++ b/Cadova Viewer/Preview/CadovaPreviewService.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+@objc public protocol CadovaPreviewService {
+    func openModel(named name: String,
+                   threeMFData: Data,
+                   reply: @escaping (Bool, String?) -> Void)
+}
+
+public enum CadovaPreview {
+    public static let machServiceName = "se.tomasf.CadovaViewer.preview"
+
+    public static var xpcInterface: NSXPCInterface {
+        NSXPCInterface(with: CadovaPreviewService.self)
+    }
+}

--- a/Cadova Viewer/Preview/CadovaPreviewService.swift
+++ b/Cadova Viewer/Preview/CadovaPreviewService.swift
@@ -1,15 +1,15 @@
 import Foundation
 
-@objc public protocol CadovaPreviewService {
+@objc protocol CadovaPreviewService {
     func openModel(named name: String,
                    threeMFData: Data,
                    reply: @escaping (Bool, String?) -> Void)
 }
 
-public enum CadovaPreview {
-    public static let machServiceName = "se.tomasf.CadovaViewer.preview"
+enum CadovaPreview {
+    static let machServiceName = "se.tomasf.CadovaViewer.preview"
 
-    public static var xpcInterface: NSXPCInterface {
+    static var xpcInterface: NSXPCInterface {
         NSXPCInterface(with: CadovaPreviewService.self)
     }
 }

--- a/Cadova Viewer/Preview/PreviewListener.swift
+++ b/Cadova Viewer/Preview/PreviewListener.swift
@@ -3,8 +3,7 @@ import Cocoa
 
 final class PreviewListener: NSObject, NSXPCListenerDelegate {
     private let listener: NSXPCListener
-    private var openDocumentsByName: [String: WeakRef<Document>] = [:]
-    private let lock = NSLock()
+    @MainActor private var openDocumentsByName: [String: WeakRef<Document>] = [:]
 
     override init() {
         listener = NSXPCListener(machServiceName: CadovaPreview.machServiceName)
@@ -25,25 +24,20 @@ final class PreviewListener: NSObject, NSXPCListenerDelegate {
 
     @MainActor
     fileprivate func openOrReplaceDocument(named name: String, threeMFData data: Data) async throws {
-        lock.lock()
-        let existing = openDocumentsByName[name]?.value
-        lock.unlock()
+        openDocumentsByName = openDocumentsByName.filter { $0.value.value != nil }
 
-        if let existing, existing.windowControllers.isEmpty == false {
+        if let existing = openDocumentsByName[name]?.value, existing.windowControllers.isEmpty == false {
             try await existing.loadFrom(data: data, name: name)
             existing.showWindows()
             return
         }
 
-        let doc = try NSDocumentController.shared.makeUntitledDocument(ofType: "org.3mf.threemfpackage") as! Document
+        let doc = Document()
         NSDocumentController.shared.addDocument(doc)
+        try await doc.loadFrom(data: data, name: name)
         doc.makeWindowControllers()
         doc.showWindows()
-        try await doc.loadFrom(data: data, name: name)
-
-        lock.lock()
         openDocumentsByName[name] = WeakRef(doc)
-        lock.unlock()
     }
 }
 

--- a/Cadova Viewer/Preview/PreviewListener.swift
+++ b/Cadova Viewer/Preview/PreviewListener.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Cocoa
+
+final class PreviewListener: NSObject, NSXPCListenerDelegate {
+    private let listener: NSXPCListener
+    private var openDocumentsByName: [String: WeakRef<Document>] = [:]
+    private let lock = NSLock()
+
+    override init() {
+        listener = NSXPCListener(machServiceName: CadovaPreview.machServiceName)
+        super.init()
+        listener.delegate = self
+    }
+
+    func start() {
+        listener.resume()
+    }
+
+    func listener(_ listener: NSXPCListener, shouldAcceptNewConnection connection: NSXPCConnection) -> Bool {
+        connection.exportedInterface = CadovaPreview.xpcInterface
+        connection.exportedObject = PreviewServiceImpl(owner: self)
+        connection.resume()
+        return true
+    }
+
+    @MainActor
+    fileprivate func openOrReplaceDocument(named name: String, threeMFData data: Data) async throws {
+        lock.lock()
+        let existing = openDocumentsByName[name]?.value
+        lock.unlock()
+
+        if let existing, existing.windowControllers.isEmpty == false {
+            try await existing.loadFrom(data: data, name: name)
+            existing.showWindows()
+            return
+        }
+
+        let doc = try NSDocumentController.shared.makeUntitledDocument(ofType: "org.3mf.threemfpackage") as! Document
+        NSDocumentController.shared.addDocument(doc)
+        doc.makeWindowControllers()
+        doc.showWindows()
+        try await doc.loadFrom(data: data, name: name)
+
+        lock.lock()
+        openDocumentsByName[name] = WeakRef(doc)
+        lock.unlock()
+    }
+}
+
+private final class WeakRef<T: AnyObject> {
+    weak var value: T?
+    init(_ value: T) { self.value = value }
+}
+
+private final class PreviewServiceImpl: NSObject, CadovaPreviewService {
+    private weak var owner: PreviewListener?
+
+    init(owner: PreviewListener) {
+        self.owner = owner
+    }
+
+    func openModel(named name: String,
+                   threeMFData: Data,
+                   reply: @escaping (Bool, String?) -> Void) {
+        guard let owner else {
+            reply(false, "Preview listener is gone")
+            return
+        }
+        Task { @MainActor in
+            do {
+                try await owner.openOrReplaceDocument(named: name, threeMFData: threeMFData)
+                reply(true, nil)
+            } catch {
+                reply(false, String(describing: error))
+            }
+        }
+    }
+}

--- a/Cadova Viewer/Views/DocumentView.swift
+++ b/Cadova Viewer/Views/DocumentView.swift
@@ -6,7 +6,7 @@ import AppKit
 import ViewerCore
 
 struct DocumentView: View {
-    let url: URL
+    let url: URL?
     let errorHandler: (Error) -> ()
     @ObservedObject var viewportController: ViewportController
     @State var isLoading = false
@@ -29,7 +29,7 @@ struct DocumentView: View {
 
     let spacer = ToolbarItem(id: NSToolbarItem.Identifier.space.rawValue, placement: .primaryAction, showsByDefault: true) { Color.clear }
 
-    init(url: URL, errorHandler: @escaping (Error) -> Void, viewportController: ViewportController) {
+    init(url: URL?, errorHandler: @escaping (Error) -> Void, viewportController: ViewportController) {
         self.url = url
         self.errorHandler = errorHandler
         self.viewportController = viewportController
@@ -152,28 +152,30 @@ struct DocumentView: View {
         }
         spacer
 
-        let apps = ExternalApplication.appsAbleToOpen(url: url)
         Group {
             ToolbarItem(id: "openIn", placement: .primaryAction, showsByDefault: true) {
-                Menu {
-                    ForEach(apps, id: \.url) { app in
-                        Button {
-                            app.open(file: url, errorHandler: errorHandler)
-                        } label: {
-                            HStack {
-                                Image(nsImage: app.icon)
-                                Text(app.name)
+                if let url {
+                    let apps = ExternalApplication.appsAbleToOpen(url: url)
+                    Menu {
+                        ForEach(apps, id: \.url) { app in
+                            Button {
+                                app.open(file: url, errorHandler: errorHandler)
+                            } label: {
+                                HStack {
+                                    Image(nsImage: app.icon)
+                                    Text(app.name)
+                                }
                             }
                         }
+                    } label: {
+                        Label {
+                            Text("Open in…")
+                        } icon: {
+                            Image(systemName: "arrowshape.turn.up.forward.fill")
+                        }
                     }
-                } label: {
-                    Label {
-                        Text("Open in…")
-                    } icon: {
-                        Image(systemName: "arrowshape.turn.up.forward.fill")
-                    }
+                    .disabled(apps.isEmpty)
                 }
-                .disabled(apps.isEmpty)
             }
         }
 
@@ -193,7 +195,9 @@ struct DocumentView: View {
             }
 
             ToolbarItem(id: "share", placement: .primaryAction, showsByDefault: false) {
-                ShareLink(item: url)
+                if let url {
+                    ShareLink(item: url)
+                }
             }
         }
     }

--- a/Packages/ViewerCore/Sources/ViewerCore/ModelData.swift
+++ b/Packages/ViewerCore/Sources/ViewerCore/ModelData.swift
@@ -73,19 +73,30 @@ extension ModelData {
     }
 }
 
+
+
 extension ModelData {
     public init(url: URL, includeEdges: Bool = true) async throws {
         let loader = ModelLoader(url: url)
         let loadedModel = try await loader.load()
+        await self.init(loadedModel: loadedModel, includeEdges: includeEdges)
+    }
 
-        struct ComponentProducts: Sendable {
-            let mainGeometry: SCNGeometry
-            let sharpEdgesGeometry: SCNGeometry
-            let smoothEdgesGeometry: SCNGeometry
-            let stats: ModelData.Statistics
-            let transform: SCNMatrix4
-        }
-
+    public init(data: Data, includeEdges: Bool = true) async throws {
+        let loader = ModelLoader(data: data)
+        let loadedModel = try await loader.load()
+        await self.init(loadedModel: loadedModel, includeEdges: includeEdges)
+    }
+	
+	private struct ComponentProducts: Sendable {
+		let mainGeometry: SCNGeometry
+		let sharpEdgesGeometry: SCNGeometry
+		let smoothEdgesGeometry: SCNGeometry
+		let stats: ModelData.Statistics
+		let transform: SCNMatrix4
+	}
+	
+    private init<Source: Sendable>(loadedModel: ModelLoader<Source>.LoadedModel, includeEdges: Bool) async {
         let indexedEdgeGeometries: [(sharp: SCNGeometry, smooth: SCNGeometry)]
         if includeEdges {
             indexedEdgeGeometries = await loadedModel.meshes.asyncMap { $0.mesh.edgeGeometries() }
@@ -343,118 +354,5 @@ extension Mesh {
             smooth: SCNGeometryElement(indices: smoothEdges.flatMap { [Int32($0.v1), Int32($0.v2)] }, primitiveType: .line)
         )
     }
-}
-
-extension ModelData {
-	public init(data: Data, includeEdges: Bool = true) async throws {
-		let loader = ModelLoader(data: data)
-		let loadedModel = try await loader.load()
-
-		struct ComponentProducts: Sendable {
-			let mainGeometry: SCNGeometry
-			let sharpEdgesGeometry: SCNGeometry
-			let smoothEdgesGeometry: SCNGeometry
-			let stats: ModelData.Statistics
-			let transform: SCNMatrix4
-		}
-
-		let indexedEdgeGeometries: [(sharp: SCNGeometry, smooth: SCNGeometry)]
-		if includeEdges {
-			indexedEdgeGeometries = await loadedModel.meshes.asyncMap { $0.mesh.edgeGeometries() }
-		} else {
-			indexedEdgeGeometries = []
-		}
-
-		let parts = await Array(loadedModel.items.enumerated()).asyncMap { itemIndex, loadedItem in
-			let products = await loadedItem.components.asyncMap { loadedComponent in
-				let property = PartialPropertyReference(groupID: loadedComponent.propertyGroupID, index: loadedComponent.propertyIndex)
-				let loadedMesh = loadedModel.meshes[loadedComponent.meshIndex]
-				let model = loadedModel.models[loadedMesh.modelIndex]
-
-				let geometry = model.geometry(for: loadedMesh.mesh, inheritedProperty: property)
-
-				if includeEdges && loadedComponent.meshIndex < indexedEdgeGeometries.count {
-					let (sharp, smooth) = indexedEdgeGeometries[loadedComponent.meshIndex]
-					return ComponentProducts(
-						mainGeometry: geometry,
-						sharpEdgesGeometry: sharp,
-						smoothEdgesGeometry: smooth,
-						stats: loadedMesh.mesh.statistics,
-						transform: loadedComponent.scnMatrix
-					)
-				} else {
-					let emptyGeometry = SCNGeometry()
-					return ComponentProducts(
-						mainGeometry: geometry,
-						sharpEdgesGeometry: emptyGeometry,
-						smoothEdgesGeometry: emptyGeometry,
-						stats: loadedMesh.mesh.statistics,
-						transform: loadedComponent.scnMatrix
-					)
-				}
-			}
-
-			var nodes = Part.Nodes()
-			nodes.container.name = "Item \(itemIndex)"
-
-			if includeEdges && loadedItem.item.semantic == .solid {
-				let sharpEdgesGroupNode = SCNNode()
-				let smoothEdgesGroupNode = SCNNode()
-				nodes.sharpEdges = sharpEdgesGroupNode
-				nodes.smoothEdges = smoothEdgesGroupNode
-				sharpEdgesGroupNode.name = "Sharp edges"
-				smoothEdgesGroupNode.name = "Smooth edges"
-				nodes.container.addChildNode(sharpEdgesGroupNode)
-				nodes.container.addChildNode(smoothEdgesGroupNode)
-
-				for product in products {
-					let sharpNodeContainer = SCNNode()
-					sharpNodeContainer.name = "Sharp edges transformer"
-					sharpNodeContainer.transform = product.transform
-					sharpEdgesGroupNode.addChildNode(sharpNodeContainer)
-
-					let sharpNode = SCNNode(geometry: product.sharpEdgesGeometry)
-					sharpNode.name = "Sharp edges geometry"
-					sharpNodeContainer.addChildNode(sharpNode)
-
-					let smoothNodeContainer = SCNNode()
-					smoothNodeContainer.name = "Smooth edges transformer"
-					smoothNodeContainer.transform = product.transform
-					smoothEdgesGroupNode.addChildNode(smoothNodeContainer)
-
-					let smoothNode = SCNNode(geometry: product.smoothEdgesGeometry)
-					smoothNode.name = "Smooth edges geometry"
-					smoothNodeContainer.addChildNode(smoothNode)
-				}
-			}
-
-			for product in products {
-				let modelNode = SCNNode(geometry: product.mainGeometry)
-				modelNode.name = "Main geometry"
-				modelNode.transform = product.transform
-				nodes.model.addChildNode(modelNode)
-			}
-
-			return Part(
-				nodes: nodes,
-				name: loadedItem.rootObject.name ?? "Object \(itemIndex + 1)",
-				id: loadedItem.item.partNumber,
-				semantic: loadedItem.item.semantic,
-				stats: Statistics(products.map(\.stats))
-			)
-		}
-
-		let container = SCNNode()
-		container.name = "Model root"
-		if let multiplier = loadedModel.rootModel.unit?.millimetersPerUnit {
-			container.transform = SCNMatrix4MakeScale(multiplier, multiplier, multiplier)
-		}
-
-		for part in parts {
-			container.addChildNode(part.nodes.container)
-		}
-
-		self = Self(rootNode: container, parts: parts, metadata: loadedModel.rootModel.metadata)
-	}
 }
 

--- a/Packages/ViewerCore/Sources/ViewerCore/ModelData.swift
+++ b/Packages/ViewerCore/Sources/ViewerCore/ModelData.swift
@@ -344,3 +344,117 @@ extension Mesh {
         )
     }
 }
+
+extension ModelData {
+	public init(data: Data, includeEdges: Bool = true) async throws {
+		let loader = ModelLoader(data: data)
+		let loadedModel = try await loader.load()
+
+		struct ComponentProducts: Sendable {
+			let mainGeometry: SCNGeometry
+			let sharpEdgesGeometry: SCNGeometry
+			let smoothEdgesGeometry: SCNGeometry
+			let stats: ModelData.Statistics
+			let transform: SCNMatrix4
+		}
+
+		let indexedEdgeGeometries: [(sharp: SCNGeometry, smooth: SCNGeometry)]
+		if includeEdges {
+			indexedEdgeGeometries = await loadedModel.meshes.asyncMap { $0.mesh.edgeGeometries() }
+		} else {
+			indexedEdgeGeometries = []
+		}
+
+		let parts = await Array(loadedModel.items.enumerated()).asyncMap { itemIndex, loadedItem in
+			let products = await loadedItem.components.asyncMap { loadedComponent in
+				let property = PartialPropertyReference(groupID: loadedComponent.propertyGroupID, index: loadedComponent.propertyIndex)
+				let loadedMesh = loadedModel.meshes[loadedComponent.meshIndex]
+				let model = loadedModel.models[loadedMesh.modelIndex]
+
+				let geometry = model.geometry(for: loadedMesh.mesh, inheritedProperty: property)
+
+				if includeEdges && loadedComponent.meshIndex < indexedEdgeGeometries.count {
+					let (sharp, smooth) = indexedEdgeGeometries[loadedComponent.meshIndex]
+					return ComponentProducts(
+						mainGeometry: geometry,
+						sharpEdgesGeometry: sharp,
+						smoothEdgesGeometry: smooth,
+						stats: loadedMesh.mesh.statistics,
+						transform: loadedComponent.scnMatrix
+					)
+				} else {
+					let emptyGeometry = SCNGeometry()
+					return ComponentProducts(
+						mainGeometry: geometry,
+						sharpEdgesGeometry: emptyGeometry,
+						smoothEdgesGeometry: emptyGeometry,
+						stats: loadedMesh.mesh.statistics,
+						transform: loadedComponent.scnMatrix
+					)
+				}
+			}
+
+			var nodes = Part.Nodes()
+			nodes.container.name = "Item \(itemIndex)"
+
+			if includeEdges && loadedItem.item.semantic == .solid {
+				let sharpEdgesGroupNode = SCNNode()
+				let smoothEdgesGroupNode = SCNNode()
+				nodes.sharpEdges = sharpEdgesGroupNode
+				nodes.smoothEdges = smoothEdgesGroupNode
+				sharpEdgesGroupNode.name = "Sharp edges"
+				smoothEdgesGroupNode.name = "Smooth edges"
+				nodes.container.addChildNode(sharpEdgesGroupNode)
+				nodes.container.addChildNode(smoothEdgesGroupNode)
+
+				for product in products {
+					let sharpNodeContainer = SCNNode()
+					sharpNodeContainer.name = "Sharp edges transformer"
+					sharpNodeContainer.transform = product.transform
+					sharpEdgesGroupNode.addChildNode(sharpNodeContainer)
+
+					let sharpNode = SCNNode(geometry: product.sharpEdgesGeometry)
+					sharpNode.name = "Sharp edges geometry"
+					sharpNodeContainer.addChildNode(sharpNode)
+
+					let smoothNodeContainer = SCNNode()
+					smoothNodeContainer.name = "Smooth edges transformer"
+					smoothNodeContainer.transform = product.transform
+					smoothEdgesGroupNode.addChildNode(smoothNodeContainer)
+
+					let smoothNode = SCNNode(geometry: product.smoothEdgesGeometry)
+					smoothNode.name = "Smooth edges geometry"
+					smoothNodeContainer.addChildNode(smoothNode)
+				}
+			}
+
+			for product in products {
+				let modelNode = SCNNode(geometry: product.mainGeometry)
+				modelNode.name = "Main geometry"
+				modelNode.transform = product.transform
+				nodes.model.addChildNode(modelNode)
+			}
+
+			return Part(
+				nodes: nodes,
+				name: loadedItem.rootObject.name ?? "Object \(itemIndex + 1)",
+				id: loadedItem.item.partNumber,
+				semantic: loadedItem.item.semantic,
+				stats: Statistics(products.map(\.stats))
+			)
+		}
+
+		let container = SCNNode()
+		container.name = "Model root"
+		if let multiplier = loadedModel.rootModel.unit?.millimetersPerUnit {
+			container.transform = SCNMatrix4MakeScale(multiplier, multiplier, multiplier)
+		}
+
+		for part in parts {
+			container.addChildNode(part.nodes.container)
+		}
+
+		self = Self(rootNode: container, parts: parts, metadata: loadedModel.rootModel.metadata)
+	}
+}
+


### PR DESCRIPTION
Hi!

Maybe there is a simpler or more efficient way to implement it but in the meantime; using [CadovaViewerKit](https://github.com/JPBeltman/CadovaViewerKit) and the changes to Cadova Viewer in this PR, in-memory models can be opened from a Cadova project in Cadova Viewer via `.preview()`. e.g. 
```
import CadovaViewerKit

let modelFile = try await ModelFileGenerator.build(named: "my-model", options: .format3D(.threeMF)) {
    Box(x: 10, y: 10, z: 5)
}

try await modelFile.preview()
```

The gist is; Cadova Viewer opens a listener that CadovaViewerKit, which has an extension for the `ModelFile`, calls. I kept it in a separate library (open to transfer it over to you, or any other suggestion you have for it's location) since Cadova Viewer is only available on MacOS and it felt out of the scope for Cadova.

Disclaimer: I could not do tests with a compiled version of Cadova Viewer outside of Xcode since I do not have the required certificates/developer account capabilities

Manual tests:
- All examples from the wiki, 3-5 times with params changed for reloading the window
  - `Loft` was initially greyed out one time, after changing a param it looked normal again. Could not replicate it again
- Examples from wiki in the form below to test opening multiple windows and reloading them 
``` 
let generator = ModelFileGenerator()

let part1 = try await generator.build(named: "model1") { ... }
let part2 = try await generator.build(named: "model2") { ... }

try await part1.preview()
try await part2.preview()
```
I did not test complicated parts (just saw the issue about part lists) or projects, feel free to share one:).

Disclaimer2: The listener is implemented via XPC and the Mach-service, I'm really not well-known with these API's so I relied heavily on forums and Claude for that implementation. While I understand what is happening & why and have tried to find pitfalls etc online, I cannot guarantee I missed something; so be cautious about obvious mistakes I guess, it works but don't think thats a good guarantee.
